### PR TITLE
Correction bouton risibank

### DIFF
--- a/JVC _Boutons_Edition.user.js
+++ b/JVC _Boutons_Edition.user.js
@@ -17,15 +17,22 @@
     let debounceTimer = null;
 
     function moveButtonsEditor() {
-        const buttonsEditor = document.querySelector('.buttonsEditor');
+        //Remontage du bloc en entier Sinon on perd le bouton
+        const buttonsEditor = document.querySelector('.messageEditor__buttonEdit');
+
+        const buttonEdit = document.querySelector('.buttonsEditor');
         const risibank = document.querySelector('#risibank-container');
         const textarea = document.querySelector('#message_topic');
 
         if (!buttonsEditor || !textarea) return;
 
+        //Switch Barre bas CSS
+        buttonsEditor.style.borderTop = 'none';
+        buttonsEditor.style.borderBottom = '0.0625rem solid var(--jv-border-color)';
+
         // Centrage
-        buttonsEditor.style.margin = 'auto';
-        buttonsEditor.style.width = 'fit-content';
+        buttonEdit.style.margin = 'auto';
+        buttonEdit.style.width = 'fit-content';
 
         // Vérifie si le déplacement est vraiment nécessaire
         const isUnderRisi = risibank && risibank.nextSibling === buttonsEditor;


### PR DESCRIPTION
Bon j'ai pas trouvé de solution miracle comme je t'ai dit sur JVC mais ça devrait faire l'affaire en fait j'ai pris le groupe parent je l'ai remonté j'ai déplacé la ligne vers le bas pour qu'il y ait la séparation et après sinon j'ai laissé le script tel 

En fait tu remontais le sous-groupe C'est pour ça que le bouton bugger là normalement il devrait pas y avoir de souci mais c'est toujours pas propre du tout mais ça fonctionne.


C'est vraiment du codage à l'arrache 
Je regarderai si j'ai plus d'informations plus tard ou si je peux te fournir un code plus propre